### PR TITLE
Add metrics to watch config reload status

### DIFF
--- a/README.md
+++ b/README.md
@@ -586,9 +586,12 @@ Metrics are exposed in [prometheus text format](https://prometheus.io/docs/instr
 | request_duration_seconds | Summary | Request duration. Includes possible queue wait time | `user`, `cluster`, `cluster_user`, `replica`, `cluster_node` |
 | proxied_response_duration_seconds | Summary | Duration for responses proxied from clickhouse | `user`, `cluster`, `cluster_user`, `replica`, `cluster_node` |
 | cached_response_duration_seconds | Summary | Duration for cached responses. Includes the duration for sending response to client | `cache`, `user`, `cluster`, `cluster_user` |
-| bad_requests_total | Counter | The number of unsupported requests | |
 | canceled_request_total | Counter | The number of requests canceled by remote client | `user`, `cluster`, `cluster_user`, `replica`, `cluster_node` |
 | timeout_request_total | Counter | The number of timed out requests | `user`, `cluster`, `cluster_user`, `replica`, `cluster_node` |
+| config_last_reload_successful | Gauge | Whether the last configuration reload attempt was successful | |
+| config_last_reload_success_timestamp_seconds | Gauge | Timestamp of the last successful configuration reload | |
+| bad_requests_total | Counter | The number of unsupported requests | |
+
 
 An example of [Grafana's](https://grafana.com) dashboard for `chproxy` metrics is available [here](https://github.com/Vertamedia/chproxy/blob/master/chproxy_overview.json)
 

--- a/main.go
+++ b/main.go
@@ -255,8 +255,11 @@ func loadConfig() (*config.Config, error) {
 	}
 	cfg, err := config.LoadFile(*configFile)
 	if err != nil {
+		configSuccess.Set(0)
 		return nil, fmt.Errorf("can't load config %q: %s", *configFile, err)
 	}
+	configSuccess.Set(1)
+	configSuccessTime.Set(float64(time.Now().Unix()))
 	return cfg, nil
 }
 

--- a/metrics.go
+++ b/metrics.go
@@ -87,10 +87,6 @@ var (
 		},
 		[]string{"user", "cluster", "cluster_user", "replica", "cluster_node"},
 	)
-	badRequest = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "bad_requests_total",
-		Help: "Total number of unsupported requests",
-	})
 	cacheHit = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "cache_hits_total",
@@ -157,6 +153,18 @@ var (
 		},
 		[]string{"user", "cluster", "cluster_user", "replica", "cluster_node"},
 	)
+	configSuccess = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "config_last_reload_successful",
+		Help: "Whether the last configuration reload attempt was successful.",
+	})
+	configSuccessTime = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "config_last_reload_success_timestamp_seconds",
+		Help: "Timestamp of the last successful configuration reload.",
+	})
+	badRequest = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "bad_requests_total",
+		Help: "Total number of unsupported requests",
+	})
 )
 
 func init() {
@@ -166,5 +174,5 @@ func init() {
 		requestBodyBytes, responseBodyBytes, badRequest,
 		cacheHit, cacheMiss, cacheSize, cacheItems,
 		requestDuration, proxiedResponseDuration, cachedResponseDuration,
-		canceledRequest, timeoutRequest)
+		canceledRequest, timeoutRequest, configSuccess, configSuccessTime)
 }


### PR DESCRIPTION
This PR adds next metrics:
* config_last_reload_successful
* config_last_reload_success_timestamp_seconds

Those metrics can be used to config alerts(based on unsuccessful conf reloads) and annotations for dashboard(display config change events)