### PR TITLE
Allow to pass `compress`, `decompress` params

### DIFF
--- a/scope.go
+++ b/scope.go
@@ -285,6 +285,8 @@ func (s *scope) killQuery() error {
 var allowedParams = []string{
 	"query",
 	"database",
+	"compress",
+	"decompress",
 	"default_format",
 }
 


### PR DESCRIPTION
If you specified ‘compress=1’ in the URL, CH will compress the data it sends you. If you specified ‘decompress=1’ in the URL, CH will decompress the same data that you pass in the POST method.

You can use this to reduce network traffic when transmitting a large amount of data, or for creating dumps that are immediately compressed.