### PR TITLE
Fix gzip for cached requests

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -269,7 +269,7 @@ func TestServe(t *testing.T) {
 				checkErr(t, err)
 				body, _ := ioutil.ReadAll(resp.Body)
 				if resp.StatusCode != http.StatusOK {
-					t.Fatalf("unexpected status code: %d; expected: %d; body: ", resp.StatusCode, http.StatusOK, string(body))
+					t.Fatalf("unexpected status code: %d; expected: %d; body: %s", resp.StatusCode, http.StatusOK, string(body))
 				}
 				resp.Body.Close()
 			},

--- a/proxy.go
+++ b/proxy.go
@@ -1,10 +1,8 @@
 package main
 
 import (
-	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -223,14 +221,13 @@ func (rp *reverseProxy) serveFromCache(s *scope, srw *statResponseWriter, req *h
 		return
 	}
 
+	// TODO: add tes case to verify that body remains unchanged
 	q, err := getFullQuery(req)
 	if err != nil {
 		err = fmt.Errorf("%s: cannot read query: %s", s, err)
 		respondWith(srw, err, http.StatusBadRequest)
 		return
 	}
-	req.Body = ioutil.NopCloser(bytes.NewBuffer(q))
-
 	if !canCacheQuery(q) {
 		// The query cannot be cached, so just proxy it.
 		rp.proxyRequest(s, srw, srw, req)

--- a/proxy.go
+++ b/proxy.go
@@ -177,8 +177,8 @@ func (rp *reverseProxy) proxyRequest(s *scope, rw http.ResponseWriter, srw *stat
 		since := float64(time.Since(startTime).Seconds())
 		proxiedResponseDuration.With(s.labels).Observe(since)
 
-		// cache.ResponseWriter writes header only on Commit/Rollback actions
-		// but they didn't happen yet
+		// cache.ResponseWriter pushes status code to srw on Commit/Rollback actions
+		// but they didn't happen yet, so manually propagate the status code from crw to srw.
 		if crw, ok := rw.(*cache.ResponseWriter); ok {
 			srw.statusCode = crw.StatusCode()
 		}

--- a/testdata/http.cache.yml
+++ b/testdata/http.cache.yml
@@ -1,0 +1,22 @@
+log_debug: true
+server:
+  http:
+      listen_addr: ":9090"
+      allowed_networks: ["127.0.0.1/24"]
+
+users:
+  - name: "default"
+    to_cluster: "default"
+    to_user: "default"
+    cache: "shortterm"
+
+clusters:
+  - name: "default"
+    nodes: ["127.0.0.1:8124"]
+
+
+caches:
+  - name: "shortterm"
+    dir: "temp-test-data/cache"
+    max_size: "10M"
+    expire: "1m"

--- a/utils.go
+++ b/utils.go
@@ -119,6 +119,8 @@ func getFullQuery(req *http.Request) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	// restore body for further reading
+	req.Body = ioutil.NopCloser(bytes.NewBuffer(data))
 	u := getDecompressor(req)
 	if u == nil {
 		return data, nil

--- a/utils_test.go
+++ b/utils_test.go
@@ -113,6 +113,7 @@ func TestGetFullQueryGzipped(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	checkResponse(t, req.Body, buf.String())
 	if string(query) != string(q) {
 		t.Fatalf("got: %q; expected %q", query, q)
 	}
@@ -138,6 +139,7 @@ func TestDecompression(t *testing.T) {
 				if err != nil {
 					return err
 				}
+				checkResponse(t, req.Body, lz4TestQuery)
 				if string(q) != testQuery {
 					return fmt.Errorf("got: %q; expected %q", string(q), testQuery)
 				}
@@ -185,6 +187,7 @@ func TestDecompression(t *testing.T) {
 				if err != nil {
 					return err
 				}
+				checkResponse(t, req.Body, zstdTestQuery)
 				if string(q) != testQuery {
 					return fmt.Errorf("got: %q; expected %q", string(q), testQuery)
 				}


### PR DESCRIPTION
If gzipped request is absent in cache, chproxy sends in-proper body value to CH.