### PR TITLE
More precisely regexp for external_data params

### DIFF
--- a/scope.go
+++ b/scope.go
@@ -302,7 +302,7 @@ var allowedParams = []string{
 
 // This regexp must match params needed to describe a way to use external data
 // @see https://clickhouse.yandex/docs/en/table_engines/external_data/
-var externalDataParams = regexp.MustCompile(`(_types|_structure|_format)(\b)`)
+var externalDataParams = regexp.MustCompile(`(_types|_structure|_format)$`)
 
 func (s *scope) decorateRequest(req *http.Request) (*http.Request, url.Values) {
 	// Make new params to purify URL.

--- a/scope_test.go
+++ b/scope_test.go
@@ -348,6 +348,12 @@ func TestDecorateRequest(t *testing.T) {
 			[]string{"query_id", "query"},
 		},
 		{
+			"http://127.0.0.1?user=default&password=default&query=SELECT&testdata_type_buzz=1&testdata_structure_foo=id+UInt32&testdata_format-bar=TSV",
+			"multipart/form-data; boundary=foobar",
+			"POST",
+			[]string{"query_id", "query", "no_cache"},
+		},
+		{
 			"http://127.0.0.1?user=default&password=default&query=SELECT&testdata_structure=id+UInt32&testdata_format=TSV",
 			"multipart/form-data; boundary=foobar",
 			"POST",
@@ -379,7 +385,7 @@ func TestDecorateRequest(t *testing.T) {
 		}
 
 		if len(tc.expectedParams) != len(params) {
-			t.Fatalf("unexpected params len")
+			t.Fatalf("unexpected params for query %q: %#v", tc.request, params)
 		}
 
 		sort.Strings(params)


### PR DESCRIPTION
> Should the regexp end with $ instead of \b, because \b matches foo_types bar?

Thx, @valyala! 