### PR TITLE
User params

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 pkgs = $(shell go list ./...)
+gofiles := $(shell find . -name "*.go" -type f -not -path "./vendor/*")
+
 
 BUILD_TAG = $(shell git tag --points-at HEAD)
 
@@ -13,9 +15,8 @@ update:
 	dep ensure -update
 
 format:
-	dep ensure
 	go fmt $(pkgs)
-	gofmt -w -s .
+	gofmt -w -s $(gofiles)
 
 build:
 	go build

--- a/README.md
+++ b/README.md
@@ -391,7 +391,8 @@ network_groups:
   - name: "reporting-apps"
     networks: ["10.10.10.0/24"]
 
-# Optional list of GET params to send with each request
+# Optional lists of query params to send with each proxied request to ClickHouse.
+# These lists may be used for overriding ClickHouse settings on a per-user basis.
 param_groups:
     # Group name, which may be passed into `params` option on the `user` level.
   - name: "cron-job"
@@ -443,6 +444,7 @@ server:
     # Certificates are automatically issued and renewed if this section
     # is present.
     # There is no need in cert_file and key_file if this section is present.
+    # Autocert requires application to listen on :80 port for certificate generation
     autocert:
       # Path to the directory where autocert certs are cached.
       cache_dir: "certs_dir"
@@ -489,9 +491,10 @@ users:
     # By default responses aren't cached.
     cache: "longterm"
 
-    # ParamGroup name to use
+    # An optional group of params to send to ClickHouse with each proxied request.
+    # These params may be set in param_groups block.
     #
-    # By default no additional params are used
+    # By default no additional params are sent to ClickHouse.
     params: "web"
 
     # The maximum number of requests that may wait for their chance

--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ an instant cache flush may be built on top of cache namespaces - just switch to 
 to flush the cache.
 
 ### Security
-`Chproxy` removes all the query params from input requests (except the `query`, `database`, `default_format`, `compress`, `decompress`, `enable_http_compression`)
+`Chproxy` removes all the query params from input requests (except the user's [params](https://github.com/Vertamedia/chproxy/blob/master/config#param_groups_config) and the `query`, `database`, `default_format`, `compress`, `decompress`, `enable_http_compression`)
 before proxying them to `ClickHouse` nodes. This prevents from unsafe overriding
 of various `ClickHouse` [settings](http://clickhouse-docs.readthedocs.io/en/latest/interfaces/http_interface.html).
 
@@ -391,6 +391,29 @@ network_groups:
   - name: "reporting-apps"
     networks: ["10.10.10.0/24"]
 
+# Optional list of GET params to send with each request
+param_groups:
+    # Group name, which may be passed into `param_groups` option on the `user` level.
+  - name: "cron-job"
+    # List of key-value params to send
+    params:
+      - key: "max_memory_usage"
+        value: "40000000000"
+
+      - key: "max_bytes_before_external_group_by"
+        value: "20000000000"
+
+  - name: "web"
+    params:
+      - key: "max_memory_usage"
+        value: "5000000000"
+
+      - key: "max_columns_to_read"
+        value: "30"
+
+      - key: "max_execution_time"
+        value: "30"
+
 # Settings for `chproxy` input interfaces.
 server:
   # Configs for input http interface.
@@ -420,7 +443,6 @@ server:
     # Certificates are automatically issued and renewed if this section
     # is present.
     # There is no need in cert_file and key_file if this section is present.
-    # Autocert requires application to listen on :80 port for certificate generation
     autocert:
       # Path to the directory where autocert certs are cached.
       cache_dir: "certs_dir"
@@ -467,6 +489,11 @@ users:
     # By default responses aren't cached.
     cache: "longterm"
 
+    # ParamGroup name to use
+    #
+    # By default no additional params are used
+    params: "web"
+
     # The maximum number of requests that may wait for their chance
     # to be executed because they cannot run now due to the current limits.
     #
@@ -487,6 +514,8 @@ users:
     to_cluster: "second cluster"
     to_user: "default"
     allowed_networks: ["office", "1.2.3.0/24"]
+
+    params: "cron-job"
 
     # The maximum number of concurrently running queries for the user.
     #

--- a/README.md
+++ b/README.md
@@ -393,7 +393,7 @@ network_groups:
 
 # Optional list of GET params to send with each request
 param_groups:
-    # Group name, which may be passed into `param_groups` option on the `user` level.
+    # Group name, which may be passed into `params` option on the `user` level.
   - name: "cron-job"
     # List of key-value params to send
     params:

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -79,12 +79,15 @@ type Key struct {
 
 	// Namespace is an optional cache namespace.
 	Namespace string
+
+	// UserParamsHash must contain hashed value of users params
+	UserParamsHash uint32
 }
 
 // String returns string representation of the key.
 func (k *Key) String() string {
-	s := fmt.Sprintf("V%d; Query=%q; AcceptEncoding=%q; DefaultFormat=%q; Database=%q; Compress=%q; EnableHTTPCompression=%q; Namespace=%q",
-		cacheVersion, k.Query, k.AcceptEncoding, k.DefaultFormat, k.Database, k.Compress, k.EnableHTTPCompression, k.Namespace)
+	s := fmt.Sprintf("V%d; Query=%q; AcceptEncoding=%q; DefaultFormat=%q; Database=%q; Compress=%q; EnableHTTPCompression=%q; Namespace=%q; UserParams=%d",
+		cacheVersion, k.Query, k.AcceptEncoding, k.DefaultFormat, k.Database, k.Compress, k.EnableHTTPCompression, k.Namespace, k.UserParamsHash)
 	h := sha256.Sum256([]byte(s))
 
 	// The first 16 bytes of the hash should be enough

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -48,14 +48,14 @@ func TestKeyString(t *testing.T) {
 			key: &Key{
 				Query: []byte("SELECT 1 FROM system.numbers LIMIT 10"),
 			},
-			expected: "cd8ba039ef5df8287ff91a3907e21fcf",
+			expected: "b84443ea3b7651f8eed84ad70cc17d55",
 		},
 		{
 			key: &Key{
 				Query:          []byte("SELECT 1 FROM system.numbers LIMIT 10"),
 				AcceptEncoding: "gzip",
 			},
-			expected: "e30d9db1d8f6a0844b7c6047d14a6c8b",
+			expected: "baece3cc15d1aa1516e2729409ece703",
 		},
 		{
 			key: &Key{
@@ -63,7 +63,7 @@ func TestKeyString(t *testing.T) {
 				AcceptEncoding: "gzip",
 				DefaultFormat:  "JSON",
 			},
-			expected: "70bd83ab8def6df2c65214b37410050c",
+			expected: "c238bde938f93419e93b5b7b0341f1ef",
 		},
 		{
 			key: &Key{
@@ -72,7 +72,7 @@ func TestKeyString(t *testing.T) {
 				DefaultFormat:  "JSON",
 				Database:       "foobar",
 			},
-			expected: "3fb481313cd5a0061832de383183ac3a",
+			expected: "e55de3951f08688a34e589caaeed437f",
 		},
 		{
 			key: &Key{
@@ -82,7 +82,7 @@ func TestKeyString(t *testing.T) {
 				Database:       "foobar",
 				Namespace:      "ns123",
 			},
-			expected: "556f114207e2f8bc4cbd574b5035b25e",
+			expected: "a8676b65119982a1fa135005e0583a07",
 		},
 		{
 			key: &Key{
@@ -93,7 +93,7 @@ func TestKeyString(t *testing.T) {
 				Compress:       "1",
 				Namespace:      "ns123",
 			},
-			expected: "5fe3d904e7e76c5fe7ba617567a4cb7a",
+			expected: "9a2ad211524d5c8983d43784fd59677d",
 		},
 	}
 

--- a/config/README.md
+++ b/config/README.md
@@ -78,7 +78,7 @@ grace_time: <duration>
 
 ### <param_groups_config>
 ```yml
-# Group name, which may be passed into `param_groups` option on the `user` level.
+# Group name, which may be passed into `params` option on the `user` level.
 - name: <string>
 # List of key-value params to send
 params:

--- a/config/README.md
+++ b/config/README.md
@@ -197,7 +197,8 @@ allowed_networks: <network_groups>, <networks> ... | optional
 # By default responses aren't cached.
 cache: <string> | optional
 
-# Optional ParamGroup name from <param_groups_config>
+# Optional group of params name to send to ClickHouse with each proxied request from <param_groups_config>
+# By default no additional params are sent to ClickHouse.
 params: <string> | optional
 ```
 

--- a/config/README.md
+++ b/config/README.md
@@ -20,6 +20,10 @@ hack_me_please <bool> | default = false [optional]
 caches:
   - <cache_config> ...
 
+# Named list of parameters to apply to each query
+param_groups:
+  - <param_groups_config> ...
+
 # Named network lists
 network_groups: <network_groups_config> ... [optional]
 
@@ -70,6 +74,16 @@ expire: <duration>
 # By default `grace_time` is 5s. Negative value disables the protection
 # from `thundering herd` problem.
 grace_time: <duration>
+```
+
+### <param_groups_config>
+```yml
+# Group name, which may be passed into `param_groups` option on the `user` level.
+- name: <string>
+# List of key-value params to send
+params:
+  - key: <string>
+    value: <string>
 ```
 
 ### <server_config>
@@ -179,9 +193,12 @@ allow_cors: <bool> | optional | default = false
 # Each list item could be IP address or subnet mask
 allowed_networks: <network_groups>, <networks> ... | optional
 
-# Optioanl reponse cache name from <cache_config>
+# Optional response cache name from <cache_config>
 # By default responses aren't cached.
 cache: <string> | optional
+
+# Optional ParamGroup name from <param_groups_config>
+params: <string> | optional
 ```
 
 ### <cluster_config>

--- a/config/config.go
+++ b/config/config.go
@@ -469,13 +469,7 @@ func (ng *NetworkGroups) UnmarshalYAML(unmarshal func(interface{}) error) error 
 	if err := unmarshal((*plain)(ng)); err != nil {
 		return err
 	}
-	if len(ng.Name) == 0 {
-		return fmt.Errorf("`network_group.name` must be specified")
-	}
-	if len(ng.Networks) == 0 {
-		return fmt.Errorf("`network_group.networks` must contain at least one network")
-	}
-	return checkOverflow(ng.XXX, fmt.Sprintf("network_group %q", ng.Name))
+	return checkOverflow(ng.XXX, "network_groups")
 }
 
 // NetworksOrGroups is a list of strings with names of NetworkGroups

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -104,6 +104,40 @@ func TestLoadConfig(t *testing.T) {
 						HeartBeatInterval: Duration(5 * time.Second),
 					},
 				},
+
+				ParamGroups: []ParamGroup{
+					{
+						Name: "cron-job",
+						Params: []Param{
+							{
+								Key:   "max_memory_usage",
+								Value: "40000000000",
+							},
+							{
+								Key:   "max_bytes_before_external_group_by",
+								Value: "20000000000",
+							},
+						},
+					},
+					{
+						Name: "web",
+						Params: []Param{
+							{
+								Key:   "max_memory_usage",
+								Value: "5000000000",
+							},
+							{
+								Key:   "max_columns_to_read",
+								Value: "30",
+							},
+							{
+								Key:   "max_execution_time",
+								Value: "30",
+							},
+						},
+					},
+				},
+
 				Users: []User{
 					{
 						Name:         "web",
@@ -116,6 +150,7 @@ func TestLoadConfig(t *testing.T) {
 						MaxQueueSize: 100,
 						MaxQueueTime: Duration(35 * time.Second),
 						Cache:        "longterm",
+						Params:       "web",
 					},
 					{
 						Name:                 "default",
@@ -125,6 +160,7 @@ func TestLoadConfig(t *testing.T) {
 						MaxExecutionTime:     Duration(time.Minute),
 						DenyHTTPS:            true,
 						NetworksOrGroups:     []string{"office", "1.2.3.0/24"},
+						Params:               "cron-job",
 					},
 				},
 				NetworkGroups: []NetworkGroups{

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -160,7 +160,6 @@ func TestLoadConfig(t *testing.T) {
 						MaxExecutionTime:     Duration(time.Minute),
 						DenyHTTPS:            true,
 						NetworksOrGroups:     []string{"office", "1.2.3.0/24"},
-						Params:               "cron-job",
 					},
 				},
 				NetworkGroups: []NetworkGroups{

--- a/config/testdata/full.yml
+++ b/config/testdata/full.yml
@@ -51,6 +51,29 @@ network_groups:
   - name: "reporting-apps"
     networks: ["10.10.10.0/24"]
 
+# Optional list of GET params to send with each request
+param_groups:
+    # Group name, which may be passed into `param_groups` option on the `user` level.
+  - name: "cron-job"
+    # List of key-value params to send
+    params:
+      - key: "max_memory_usage"
+        value: "40000000000"
+
+      - key: "max_bytes_before_external_group_by"
+        value: "20000000000"
+
+  - name: "web"
+    params:
+      - key: "max_memory_usage"
+        value: "5000000000"
+
+      - key: "max_columns_to_read"
+        value: "30"
+
+      - key: "max_execution_time"
+        value: "30"
+
 # Settings for `chproxy` input interfaces.
 server:
   # Configs for input http interface.
@@ -126,6 +149,11 @@ users:
     # By default responses aren't cached.
     cache: "longterm"
 
+    # ParamGroup name to use
+    #
+    # By default no additional params are used
+    params: "web"
+
     # The maximum number of requests that may wait for their chance
     # to be executed because they cannot run now due to the current limits.
     #
@@ -146,6 +174,8 @@ users:
     to_cluster: "second cluster"
     to_user: "default"
     allowed_networks: ["office", "1.2.3.0/24"]
+
+    params: "cron-job"
 
     # The maximum number of concurrently running queries for the user.
     #

--- a/config/testdata/full.yml
+++ b/config/testdata/full.yml
@@ -53,7 +53,7 @@ network_groups:
 
 # Optional list of GET params to send with each request
 param_groups:
-    # Group name, which may be passed into `param_groups` option on the `user` level.
+    # Group name, which may be passed into `params` option on the `user` level.
   - name: "cron-job"
     # List of key-value params to send
     params:

--- a/config/testdata/full.yml
+++ b/config/testdata/full.yml
@@ -51,7 +51,8 @@ network_groups:
   - name: "reporting-apps"
     networks: ["10.10.10.0/24"]
 
-# Optional list of GET params to send with each request
+# Optional lists of query params to send with each proxied request to ClickHouse.
+# These lists may be used for overriding ClickHouse settings on a per-user basis.
 param_groups:
     # Group name, which may be passed into `params` option on the `user` level.
   - name: "cron-job"
@@ -103,6 +104,7 @@ server:
     # Certificates are automatically issued and renewed if this section
     # is present.
     # There is no need in cert_file and key_file if this section is present.
+    # Autocert requires application to listen on :80 port for certificate generation
     autocert:
       # Path to the directory where autocert certs are cached.
       cache_dir: "certs_dir"
@@ -149,9 +151,10 @@ users:
     # By default responses aren't cached.
     cache: "longterm"
 
-    # ParamGroup name to use
+    # An optional group of params to send to ClickHouse with each proxied request.
+    # These params may be set in param_groups block.
     #
-    # By default no additional params are used
+    # By default no additional params are sent to ClickHouse.
     params: "web"
 
     # The maximum number of requests that may wait for their chance
@@ -174,8 +177,6 @@ users:
     to_cluster: "second cluster"
     to_user: "default"
     allowed_networks: ["office", "1.2.3.0/24"]
-
-    params: "cron-job"
 
     # The maximum number of concurrently running queries for the user.
     #

--- a/proxy.go
+++ b/proxy.go
@@ -216,6 +216,7 @@ func (rp *reverseProxy) proxyRequest(s *scope, rw http.ResponseWriter, srw *stat
 		err = fmt.Errorf("%s: %s; query: %q", s, timeoutErrMsg, q)
 		respondWith(rw, err, http.StatusGatewayTimeout)
 		srw.statusCode = http.StatusGatewayTimeout
+
 	default:
 		panic(fmt.Sprintf("BUG: context.Context.Err() returned unexpected error: %s", err))
 	}
@@ -368,7 +369,6 @@ func (rp *reverseProxy) applyConfig(cfg *config.Config) error {
 		caches:   caches,
 		params:   params,
 	}
-
 	users, err := profile.newUsers()
 	if err != nil {
 		return err

--- a/scope.go
+++ b/scope.go
@@ -310,8 +310,10 @@ func (s *scope) decorateRequest(req *http.Request) (*http.Request, url.Values) {
 	params := make(url.Values)
 
 	// Set user params
-	for param, val := range s.user.params.r {
-		params.Set(param, val)
+	if s.user.params != nil {
+		for param, val := range s.user.params.r {
+			params.Set(param, val)
+		}
 	}
 
 	// Keep allowed params.
@@ -489,7 +491,7 @@ func (up usersProfile) newUser(u config.User) (*user, error) {
 	if len(u.Params) > 0 {
 		params = up.params[u.Params]
 		if params == nil {
-			return nil, fmt.Errorf("unknown `groupParam` %q", u.Params)
+			return nil, fmt.Errorf("unknown `params` %q", u.Params)
 		}
 	}
 

--- a/scope_test.go
+++ b/scope_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Vertamedia/chproxy/config"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -344,8 +345,11 @@ func TestDecorateRequest(t *testing.T) {
 			"POST",
 			&paramsRegistry{
 				key: uint32(1),
-				r: map[string]string{
-					"max_threads": "1",
+				params: []config.Param{
+					{
+						Key:   "max_threads",
+						Value: "1",
+					},
 				},
 			},
 			[]string{"query_id", "query", "max_threads"},
@@ -356,8 +360,11 @@ func TestDecorateRequest(t *testing.T) {
 			"PUT",
 			&paramsRegistry{
 				key: uint32(1),
-				r: map[string]string{
-					"query": "1",
+				params: []config.Param{
+					{
+						Key:   "query",
+						Value: "1",
+					},
 				},
 			},
 			[]string{"query_id", "query"},
@@ -368,9 +375,15 @@ func TestDecorateRequest(t *testing.T) {
 			"POST",
 			&paramsRegistry{
 				key: uint32(1),
-				r: map[string]string{
-					"max_threads":          "1",
-					"background_pool_size": "10",
+				params: []config.Param{
+					{
+						Key:   "max_threads",
+						Value: "1",
+					},
+					{
+						Key:   "background_pool_size",
+						Value: "10",
+					},
 				},
 			},
 			[]string{"query_id", "query", "no_cache", "max_threads", "background_pool_size"},


### PR DESCRIPTION
This PR allows to create `param_groups` - named lists of URL params. If the group is attached to `user` in `params` option, proxy will send those params with every user's request.

The `param_groups` configuration is following:
```
# Optional list of GET params to send with each request
param_groups:
    # Group name, which may be passed into `params` option on the `user` level.
  - name: "cron-job"
    # List of key-value params to send
    params:
      - key: "max_memory_usage"
        value: "40000000000"

      - key: "max_bytes_before_external_group_by"
        value: "20000000000"
```

Caching is still available while using `param_groups`. Proxy will get a hash from the params list and use it as a part of `cache.Key`