### PR TITLE
commit about cache and grace time problems.

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -377,7 +377,7 @@ again:
 		if time.Since(startTime) > c.graceTime {
 			// The entry didn't appear during graceTime.
 			// Let the caller creating it.
-			return nil, ErrMissing
+			return nil, ErrGraceTimeElapsed
 		}
 
 		// Wait for graceTime in the hope the entry will appear
@@ -413,6 +413,7 @@ again:
 
 // ErrMissing is returned when the entry isn't found in the cache.
 var ErrMissing = errors.New("missing cache entry")
+var ErrGraceTimeElapsed = errors.New("refused request when grace time elapsed")
 
 func (c *Cache) registerPendingEntry(path string) bool {
 	if c.graceTime <= 0 {

--- a/proxy.go
+++ b/proxy.go
@@ -286,7 +286,7 @@ func (rp *reverseProxy) serveFromCache(s *scope, srw *statResponseWriter, req *h
 		log.Debugf("%s: cache hit", s)
 		return
 	}
-
+    // If clickhouse does not response in grace time, we can return error to client.
 	if err == cache.ErrGraceTimeElapsed {
 		// grace time refuse error while serving the response.
 		err = fmt.Errorf("%s: %s; query: %q", s, err, q)


### PR DESCRIPTION
1.If we can find the result in the cache, return it directly.
2. If clickhouse does not respond in grace_time, we clear all the duplicated requests and return errors to client.