### PR TITLE
Consistent response times in Microseconds

### DIFF
--- a/scope.go
+++ b/scope.go
@@ -84,7 +84,7 @@ func (s *scope) String() string {
 		s.user.name, s.user.queryCounter.load(),
 		s.clusterUser.name, s.clusterUser.queryCounter.load(),
 		s.host.addr.Host, s.host.load(),
-		s.remoteAddr, s.localAddr, time.Since(s.startTime))
+		s.remoteAddr, s.localAddr, time.Since(s.startTime).Microseconds())
 }
 
 func (s *scope) incQueued() error {


### PR DESCRIPTION
The response times logging is inconsistent. Sometimes it is printing in microseconds and sometimes milliseconds.
Changing to always use microseconds for printing the response times so that logs can be parsed to extract this metric.