### PR TITLE
Use Go 1.13 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11-alpine AS build
+FROM golang:1.13-alpine AS build
 
 RUN apk add --update zstd-static zstd-dev make gcc musl-dev git
 RUN go get golang.org/x/lint/golint


### PR DESCRIPTION
Build docker image with newer Go (and same as go.mod specifies).
