### PR TITLE
fix get query from body of GET request

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -47,7 +47,7 @@ func getAuth(req *http.Request) (string, string) {
 //
 // getQuerySnippet must be called only for error reporting.
 func getQuerySnippet(req *http.Request) string {
-	if req.Method == http.MethodGet {
+	if req.Method == http.MethodGet && req.URL.Query().Get("query") != "" {
 		return req.URL.Query().Get("query")
 	}
 
@@ -84,7 +84,7 @@ func getQuerySnippet(req *http.Request) string {
 
 // getFullQuery returns full query from req.
 func getFullQuery(req *http.Request) ([]byte, error) {
-	if req.Method == http.MethodGet {
+	if req.Method == http.MethodGet && req.URL.Query().Get("query") != "" {
 		return []byte(req.URL.Query().Get("query")), nil
 	}
 	data, err := ioutil.ReadAll(req.Body)

--- a/utils.go
+++ b/utils.go
@@ -58,6 +58,10 @@ func getQuerySnippet(req *http.Request) string {
 }
 
 func getQuerySnippetFromBody(req *http.Request) string {
+	if req.Body == nil {
+		return ""
+	}
+
 	crc, ok := req.Body.(*cachedReadCloser)
 	if !ok {
 		crc = &cachedReadCloser{
@@ -113,6 +117,10 @@ func getFullQuery(req *http.Request) ([]byte, error) {
 }
 
 func getFullQueryFromBody(req *http.Request) ([]byte, error) {
+	if req.Body == nil {
+		return nil, nil
+	}
+
 	data, err := ioutil.ReadAll(req.Body)
 	if err != nil {
 		return nil, err

--- a/utils_test.go
+++ b/utils_test.go
@@ -80,6 +80,17 @@ func TestGetQuerySnippetGET(t *testing.T) {
 	}
 }
 
+func TestGetQuerySnippetGETBody(t *testing.T) {
+	q := "SELECT column FROM table"
+	body := bytes.NewBufferString(q)
+	req, err := http.NewRequest("GET", "", body)
+	checkErr(t, err)
+	query := getQuerySnippet(req)
+	if query != q {
+		t.Fatalf("got: %q; expected: %q", query, q)
+	}
+}
+
 func TestGetQuerySnippetPOST(t *testing.T) {
 	q := "SELECT column FROM table"
 	body := bytes.NewBufferString(q)

--- a/utils_test.go
+++ b/utils_test.go
@@ -68,7 +68,7 @@ func testCanCacheQuery(t *testing.T, q string, expected bool) {
 }
 
 func TestGetQuerySnippetGET(t *testing.T) {
-	req, err := http.NewRequest("GET", "", nil)
+	req, err := http.NewRequest("GET", "", bytes.NewBuffer(nil))
 	checkErr(t, err)
 	params := make(url.Values)
 	q := "SELECT column FROM table"
@@ -88,6 +88,25 @@ func TestGetQuerySnippetGETBody(t *testing.T) {
 	query := getQuerySnippet(req)
 	if query != q {
 		t.Fatalf("got: %q; expected: %q", query, q)
+	}
+}
+
+func TestGetQuerySnippetGETBothQueryAndBody(t *testing.T) {
+	queryPart := "SELECT column"
+	bodyPart := "FROM table"
+	expectedQuery := "SELECT column\nFROM table"
+
+	body := bytes.NewBufferString(bodyPart)
+	req, err := http.NewRequest("GET", "", body)
+	checkErr(t, err)
+
+	params := make(url.Values)
+	params.Set("query", queryPart)
+	req.URL.RawQuery = params.Encode()
+
+	query := getQuerySnippet(req)
+	if query != expectedQuery {
+		t.Fatalf("got: %q; expected: %q", query, expectedQuery)
 	}
 }
 

--- a/utils_test.go
+++ b/utils_test.go
@@ -68,7 +68,7 @@ func testCanCacheQuery(t *testing.T, q string, expected bool) {
 }
 
 func TestGetQuerySnippetGET(t *testing.T) {
-	req, err := http.NewRequest("GET", "", bytes.NewBuffer(nil))
+	req, err := http.NewRequest("GET", "", nil)
 	checkErr(t, err)
 	params := make(url.Values)
 	q := "SELECT column FROM table"


### PR DESCRIPTION
We found that if use the most popular Golang HTTP driver for Clickhouse (https://github.com/mailru/go-clickhouse) Chproxy doesn't cache requests. It's related to how to get a query for the library the query is passed via the body (for POST and  GET).
https://github.com/mailru/go-clickhouse/blob/e48216604dfdd66cdace05708e5c7c745baf21f7/conn.go#L300

The Clickhouse  HTTP server works correctly if send query into body of a GET request. Also the Clickhouse HTTP server support split query by query URL parameter and body for a GET request.
https://clickhouse.tech/docs/en/interfaces/http/
