### PR TITLE
Add support for WITH query

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -146,12 +146,11 @@ var cachableStatements = []string{"SELECT", "WITH"}
 func canCacheQuery(q []byte) bool {
 	q = skipLeadingComments(q)
 
-	// Currently only SELECT queries may be cached.
-	if len(q) < len("SELECT") {
-		return false
-	}
-
 	for _, statement := range cachableStatements {
+		if len(q) < len(statement) {
+			continue
+		}
+
 		l := bytes.ToUpper(q[:len(statement)])
 		if bytes.HasPrefix(l, []byte(statement)) {
 			return true

--- a/utils.go
+++ b/utils.go
@@ -140,6 +140,8 @@ func getFullQueryFromBody(req *http.Request) ([]byte, error) {
 	return b, nil
 }
 
+var allowedQueries = []string{"SELECT", "WITH"}
+
 // canCacheQuery returns true if q can be cached.
 func canCacheQuery(q []byte) bool {
 	q = skipLeadingComments(q)
@@ -148,8 +150,15 @@ func canCacheQuery(q []byte) bool {
 	if len(q) < len("SELECT") {
 		return false
 	}
-	q = bytes.ToUpper(q[:len("SELECT")])
-	return bytes.HasPrefix(q, []byte("SELECT"))
+
+	for _, queryPrefix := range allowedQueries {
+		l := bytes.ToUpper(q[:len(queryPrefix)])
+		if bytes.HasPrefix(l, []byte(queryPrefix)) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func skipLeadingComments(q []byte) []byte {

--- a/utils.go
+++ b/utils.go
@@ -140,7 +140,7 @@ func getFullQueryFromBody(req *http.Request) ([]byte, error) {
 	return b, nil
 }
 
-var allowedQueries = []string{"SELECT", "WITH"}
+var cachableStatements = []string{"SELECT", "WITH"}
 
 // canCacheQuery returns true if q can be cached.
 func canCacheQuery(q []byte) bool {
@@ -151,9 +151,9 @@ func canCacheQuery(q []byte) bool {
 		return false
 	}
 
-	for _, queryPrefix := range allowedQueries {
-		l := bytes.ToUpper(q[:len(queryPrefix)])
-		if bytes.HasPrefix(l, []byte(queryPrefix)) {
+	for _, statement := range cachableStatements {
+		l := bytes.ToUpper(q[:len(statement)])
+		if bytes.HasPrefix(l, []byte(statement)) {
 			return true
 		}
 	}

--- a/utils_test.go
+++ b/utils_test.go
@@ -57,6 +57,7 @@ func TestCanCacheQuery(t *testing.T) {
 	testCanCacheQuery(t, "\t\t   sElECt 123   ", true)
 	testCanCacheQuery(t, "   --- sd s\n /* dfsf */\n seleCT ", true)
 	testCanCacheQuery(t, "   --- sd s\n /* dfsf */\n insert ", false)
+	testCanCacheQuery(t, "WITH 1 as alias SELECT alias FROM nothing ", true)
 }
 
 func testCanCacheQuery(t *testing.T, q string, expected bool) {


### PR DESCRIPTION
As pointed out in the issue #106 chproxy lacks caching abilities for `WITH` queries.
The purpose of this PR is to add it. 