### PR TITLE
Sticky Sessions: Tolerate ClickHouse Session ID Mechanism

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ RUN go get golang.org/x/lint/golint
 RUN mkdir -p /go/src/github.com/Vertamedia/chproxy
 WORKDIR /go/src/github.com/Vertamedia/chproxy
 COPY . ./
+ARG EXT_BUILD_TAG
+ENV EXT_BUILD_TAG ${EXT_BUILD_TAG}
 RUN make release-build
 
 FROM alpine

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
+current_dir = $(pwd)
 pkgs = $(shell go list ./...)
 gofiles := $(shell find . -name "*.go" -type f -not -path "./vendor/*")
 
-BUILD_TAG = $(shell git tag --points-at HEAD)
+BUILD_TAG = $(or $(shell git tag --points-at HEAD), $(EXT_BUILD_TAG), latest)
 
 BUILD_CONSTS = \
 	-X main.buildTime=`date -u '+%Y-%m-%d_%H:%M:%S'` \
@@ -36,7 +37,16 @@ clean:
 	rm -f chproxy
 
 release-build:
+	@echo "Ver: $(BUILD_TAG), OPTS: $(BUILD_OPTS)"
 	GOOS=linux GOARCH=amd64 go build $(BUILD_OPTS)
+	rm chproxy-linux-amd64-*.tar.gz
+	tar czf chproxy-linux-amd64-$(BUILD_TAG).tar.gz chproxy
 
 release: format lint test clean release-build
+	@echo "Ver: $(BUILD_TAG), OPTS: $(BUILD_OPTS)"
 	tar czf chproxy-linux-amd64-$(BUILD_TAG).tar.gz chproxy
+
+release-build-docker:
+	@echo "Ver: $(BUILD_TAG)"
+	@DOCKER_BUILDKIT=1 docker build --target build --build-arg EXT_BUILD_TAG=$(BUILD_TAG) --progress plain -t chproxy-build .
+	@docker run --rm --entrypoint "/bin/sh" -v $(CURDIR):/host chproxy-build -c "/bin/cp /go/src/github.com/Vertamedia/chproxy/*.tar.gz /host"

--- a/main_test.go
+++ b/main_test.go
@@ -297,7 +297,7 @@ func TestServe(t *testing.T) {
 				resp, err := http.DefaultClient.Do(req)
 				checkErr(t, err)
 
-				if resp.StatusCode != http.StatusOK || resp.Header.Get("X-Clickhouse-Server-Session-Id") == "" {
+				if resp.StatusCode != http.StatusOK || resp.StatusCode != http.StatusOK && resp.Header.Get("X-Clickhouse-Server-Session-Id") == "" {
 					t.Fatalf("unexpected status code: %d; expected: %d", resp.StatusCode, http.StatusOK)
 				}
 				resp.Body.Close()

--- a/main_test.go
+++ b/main_test.go
@@ -285,6 +285,28 @@ func TestServe(t *testing.T) {
 			startHTTP,
 		},
 		{
+			"http POST request with session id",
+			"testdata/http-session-id.yml",
+			func(t *testing.T) {
+				// buf := bytes.NewBufferString("SELECT * FROM system.numbers LIMIT 10")
+				data := url.Values{}
+				data.Set("query", `SELECT * FROM system.numbers LIMIT 10`)
+				data.Add("session_id", "1234")
+				data.Add("query_id", "1234")
+				req, err := http.NewRequest("POST", "http://127.0.0.1:9090/", bytes.NewBufferString(data.Encode()))
+				req.Header.Set("Content-Type", "application/x-www-form-urlencoded; param=value") // This makes it work
+
+				checkErr(t, err)
+				resp, err := http.DefaultClient.Do(req)
+				checkErr(t, err)
+				if resp.StatusCode != http.StatusOK {
+					t.Fatalf("unexpected status code: %d; expected: %d", resp.StatusCode, http.StatusOK)
+				}
+				resp.Body.Close()
+			},
+			startHTTP,
+		},
+		{
 			"http request",
 			"testdata/http.yml",
 			func(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -288,7 +288,9 @@ func TestServe(t *testing.T) {
 			"http POST request with session id",
 			"testdata/http-session-id.yml",
 			func(t *testing.T) {
-				req, err := http.NewRequest("POST", "http://127.0.0.1:9090/?query_id=45395792-a432-4b92-8cc9-536c14e1e1a9&extremes=0&session_id=default-session-id233", bytes.NewBufferString("SELECT * FROM system.numbers LIMIT 10"))
+				req, err := http.NewRequest("POST",
+					"http://127.0.0.1:9090/?query_id=45395792-a432-4b92-8cc9-536c14e1e1a9&extremes=0&session_id=default-session-id233",
+					bytes.NewBufferString("SELECT * FROM system.numbers LIMIT 10"))
 				req.Header.Set("Content-Type", "application/x-www-form-urlencoded;") // This makes it work
 
 				checkErr(t, err)

--- a/main_test.go
+++ b/main_test.go
@@ -288,18 +288,14 @@ func TestServe(t *testing.T) {
 			"http POST request with session id",
 			"testdata/http-session-id.yml",
 			func(t *testing.T) {
-				// buf := bytes.NewBufferString("SELECT * FROM system.numbers LIMIT 10")
-				data := url.Values{}
-				data.Set("query", `SELECT * FROM system.numbers LIMIT 10`)
-				data.Add("session_id", "1234")
-				data.Add("query_id", "1234")
-				req, err := http.NewRequest("POST", "http://127.0.0.1:9090/", bytes.NewBufferString(data.Encode()))
-				req.Header.Set("Content-Type", "application/x-www-form-urlencoded; param=value") // This makes it work
+				req, err := http.NewRequest("POST", "http://127.0.0.1:9090/?query_id=45395792-a432-4b92-8cc9-536c14e1e1a9&extremes=0&session_id=default-session-id233", bytes.NewBufferString("SELECT * FROM system.numbers LIMIT 10"))
+				req.Header.Set("Content-Type", "application/x-www-form-urlencoded;") // This makes it work
 
 				checkErr(t, err)
 				resp, err := http.DefaultClient.Do(req)
 				checkErr(t, err)
-				if resp.StatusCode != http.StatusOK {
+
+				if resp.StatusCode != http.StatusOK || resp.Header.Get("X-Clickhouse-Server-Session-Id") == "" {
 					t.Fatalf("unexpected status code: %d; expected: %d", resp.StatusCode, http.StatusOK)
 				}
 				resp.Body.Close()

--- a/proxy.go
+++ b/proxy.go
@@ -435,7 +435,7 @@ func (rp *reverseProxy) applyConfig(cfg *config.Config) error {
 	return nil
 }
 
-// refreshCacheMetrics refresehs cacheSize and cacheItems metrics.
+// refreshCacheMetrics refreshes cacheSize and cacheItems metrics.
 func (rp *reverseProxy) refreshCacheMetrics() {
 	rp.lock.RLock()
 	defer rp.lock.RUnlock()
@@ -452,7 +452,7 @@ func (rp *reverseProxy) refreshCacheMetrics() {
 
 func (rp *reverseProxy) getScope(req *http.Request) (*scope, int, error) {
 	name, password := getAuth(req)
-
+	sessionId := getSessionId(req)
 	var (
 		u  *user
 		c  *cluster
@@ -467,6 +467,7 @@ func (rp *reverseProxy) getScope(req *http.Request) (*scope, int, error) {
 		// Fix applyConfig if c or cu equal to nil.
 		c = rp.clusters[u.toCluster]
 		cu = c.users[u.toUser]
+		c.sessionId = sessionId
 	}
 	rp.lock.RUnlock()
 

--- a/proxy.go
+++ b/proxy.go
@@ -457,6 +457,7 @@ func (rp *reverseProxy) refreshCacheMetrics() {
 func (rp *reverseProxy) getScope(req *http.Request) (*scope, int, error) {
 	name, password := getAuth(req)
 	sessionId := getSessionId(req)
+	sessionTimeout := getSessionTimeout(req)
 	var (
 		u  *user
 		c  *cluster
@@ -493,6 +494,6 @@ func (rp *reverseProxy) getScope(req *http.Request) (*scope, int, error) {
 		return nil, http.StatusForbidden, fmt.Errorf("cluster user %q is not allowed to access", cu.name)
 	}
 
-	s := newScope(req, u, c, cu, sessionId)
+	s := newScope(req, u, c, cu, sessionId, sessionTimeout)
 	return s, 0, nil
 }

--- a/proxy.go
+++ b/proxy.go
@@ -98,6 +98,11 @@ func (rp *reverseProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		ReadCloser: req.Body,
 	}
 
+	// publish session_id if needed
+	if s.sessionId != "" {
+		rw.Header().Set("X-ClickHouse-Server-Session-Id", s.sessionId)
+	}
+
 	if s.user.cache == nil {
 		rp.proxyRequest(s, srw, srw, req)
 	} else {
@@ -112,11 +117,6 @@ func (rp *reverseProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		log.Debugf("%s: request success; query: %q; Method: %s; URL: %q", s, q, req.Method, req.URL.String())
 	} else {
 		log.Debugf("%s: request failure: non-200 status code %d; query: %q; Method: %s; URL: %q", s, srw.statusCode, q, req.Method, req.URL.String())
-	}
-
-	// publish session_id if needed
-	if s.sessionId != "" {
-		rw.Header().Set("X-ClickHouse-Session-Id", s.sessionId)
 	}
 
 	statusCodes.With(

--- a/proxy.go
+++ b/proxy.go
@@ -52,9 +52,6 @@ func newReverseProxy() *reverseProxy {
 func (rp *reverseProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	startTime := time.Now()
 	s, status, err := rp.getScope(req)
-	if s.sessionId != "" {
-		rw.Header().Set("X-ClickHouse-Session-Id", s.sessionId)
-	}
 	if err != nil {
 		q := getQuerySnippet(req)
 		err = fmt.Errorf("%q: %s; query: %q", req.RemoteAddr, err, q)
@@ -115,6 +112,11 @@ func (rp *reverseProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		log.Debugf("%s: request success; query: %q; Method: %s; URL: %q", s, q, req.Method, req.URL.String())
 	} else {
 		log.Debugf("%s: request failure: non-200 status code %d; query: %q; Method: %s; URL: %q", s, srw.statusCode, q, req.Method, req.URL.String())
+	}
+
+	// publish session_id if needed
+	if s.sessionId != "" {
+		rw.Header().Set("X-ClickHouse-Session-Id", s.sessionId)
 	}
 
 	statusCodes.With(

--- a/proxy.go
+++ b/proxy.go
@@ -110,9 +110,9 @@ func (rp *reverseProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	q := getQuerySnippet(req)
 	if srw.statusCode == http.StatusOK {
 		requestSuccess.With(s.labels).Inc()
-		log.Debugf("%s: request success; query: %q; URL: %q", s, q, req.URL.String())
+		log.Debugf("%s: request success; query: %q; Method: %s; URL: %q", s, q, req.Method, req.URL.String())
 	} else {
-		log.Debugf("%s: request failure: non-200 status code %d; query: %q; URL: %q", s, srw.statusCode, q, req.URL.String())
+		log.Debugf("%s: request failure: non-200 status code %d; query: %q; Method: %s; URL: %q", s, srw.statusCode, q, req.Method, req.URL.String())
 	}
 
 	statusCodes.With(

--- a/scope.go
+++ b/scope.go
@@ -842,18 +842,16 @@ func (r *replica) getHostSticky(sessionId string) *host {
 		tmpIdx := (idx + i) % n
 
 		// handling sticky session
-		if sessionId != "" {
-			sessionId := hash(sessionId)
-			tmpIdx = (sessionId) % n
-			tmpHSticky := r.hosts[tmpIdx]
-			log.Debugf("Sticky server candidate is: %s", tmpHSticky.addr)
-			if !tmpHSticky.isActive() {
-				log.Debugf("Sticky session server has been picked up, but it is not available")
-				continue
-			}
-			log.Debugf("Sticky session server is: %s, session_id: %d, server_idx: %d, max nodes in pool: %d", tmpHSticky.addr, sessionId, tmpIdx, n)
-			return tmpHSticky
+		sessionId := hash(sessionId)
+		tmpIdx = (sessionId) % n
+		tmpHSticky := r.hosts[tmpIdx]
+		log.Debugf("Sticky server candidate is: %s", tmpHSticky.addr)
+		if !tmpHSticky.isActive() {
+			log.Debugf("Sticky session server has been picked up, but it is not available")
+			continue
 		}
+		log.Debugf("Sticky session server is: %s, session_id: %d, server_idx: %d, max nodes in pool: %d", tmpHSticky.addr, sessionId, tmpIdx, n)
+		return tmpHSticky
 	}
 
 	// The returned host may be inactive. This is OK,

--- a/scope.go
+++ b/scope.go
@@ -20,8 +20,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-// var route = make(map[int]*host)
-
 type scopeID uint64
 
 func (sid scopeID) String() string {

--- a/scope.go
+++ b/scope.go
@@ -846,14 +846,14 @@ func (r *replica) getHost() *host {
 			tmpIdx = (sessionId) % n
 			tmpHSticky := r.hosts[tmpIdx]
 			if !tmpHSticky.isActive() {
-				log.Debugf("Sticky Session Server has been picked up but not available")
+				log.Debugf("Sticky Session Server has been picked up, but it is not available")
 				continue
 			}
 			log.Debugf("Sticky Session Server is: %s, session: %d, idx mod: %d - %d", tmpH.addr, sessionId, tmpIdx, n)
 			return tmpH
 		}
 
-		// continue as usual
+		// handling least loaded host flow
 		tmpReqs := tmpH.load()
 
 		if !tmpH.isActive() {

--- a/scope_test.go
+++ b/scope_test.go
@@ -330,14 +330,14 @@ func TestDecorateRequest(t *testing.T) {
 			"text/plain",
 			"GET",
 			nil,
-			[]string{"query_id", "query"},
+			[]string{"query_id", "session_timeout", "query"},
 		},
 		{
 			"http://127.0.0.1?user=default&password=default&query=SELECT&database=default&wait_end_of_query=1",
 			"text/plain",
 			"GET",
 			nil,
-			[]string{"query_id", "query", "database"},
+			[]string{"query_id", "session_timeout", "query", "database"},
 		},
 		{
 			"http://127.0.0.1?user=default&password=default&query=SELECT&testdata_structure=id+UInt32&testdata_format=TSV",
@@ -352,7 +352,7 @@ func TestDecorateRequest(t *testing.T) {
 					},
 				},
 			},
-			[]string{"query_id", "query", "max_threads"},
+			[]string{"query_id", "session_timeout", "query", "max_threads"},
 		},
 		{
 			"http://127.0.0.1?user=default&password=default&query=SELECT&testdata_structure=id+UInt32&testdata_format=TSV",
@@ -367,7 +367,7 @@ func TestDecorateRequest(t *testing.T) {
 					},
 				},
 			},
-			[]string{"query_id", "query"},
+			[]string{"query_id", "session_timeout", "query"},
 		},
 		{
 			"http://127.0.0.1?user=default&password=default&query=SELECT&testdata_type_buzz=1&testdata_structure_foo=id+UInt32&testdata_format-bar=TSV",
@@ -386,14 +386,14 @@ func TestDecorateRequest(t *testing.T) {
 					},
 				},
 			},
-			[]string{"query_id", "query", "max_threads", "background_pool_size"},
+			[]string{"query_id", "session_timeout", "query", "max_threads", "background_pool_size"},
 		},
 		{
 			"http://127.0.0.1?user=default&password=default&query=SELECT&testdata_structure=id+UInt32&testdata_format=TSV",
 			"multipart/form-data; boundary=foobar",
 			"POST",
 			nil,
-			[]string{"query_id", "testdata_structure", "testdata_format", "query"},
+			[]string{"query_id", "session_timeout", "testdata_structure", "testdata_format", "query"},
 		},
 	}
 

--- a/testdata/http-session-id.yml
+++ b/testdata/http-session-id.yml
@@ -1,0 +1,15 @@
+log_debug: true
+server:
+  http:
+      listen_addr: ":9090"
+      allowed_networks: ["127.0.0.1/24"]
+
+users:
+  - name: "default"
+    to_cluster: "default"
+    to_user: "default"
+
+clusters:
+  - name: "default"
+    nodes:
+      - 127.0.0.1:8124

--- a/utils.go
+++ b/utils.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/Vertamedia/chproxy/chdecompressor"
@@ -49,6 +50,16 @@ func getSessionId(req *http.Request) string {
 	params := req.URL.Query()
 	sessionId := params.Get("session_id")
 	return sessionId
+}
+
+// getSessionId retrieves session id
+func getSessionTimeout(req *http.Request) int {
+	params := req.URL.Query()
+	sessionTimeout, err := strconv.Atoi(params.Get("session_timeout"))
+	if err != nil && sessionTimeout > 0 {
+		return sessionTimeout
+	}
+	return 60
 }
 
 // getQuerySnippet returns query snippet.

--- a/utils.go
+++ b/utils.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"fmt"
+	"hash/fnv"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -43,6 +44,12 @@ func getAuth(req *http.Request) (string, string) {
 	return "default", ""
 }
 
+// getSessionId retrieves session id
+func getSessionId(req *http.Request) string {
+	params := req.URL.Query()
+	return params.Get("session_id")
+}
+
 // getQuerySnippet returns query snippet.
 //
 // getQuerySnippet must be called only for error reporting.
@@ -55,6 +62,12 @@ func getQuerySnippet(req *http.Request) string {
 	}
 
 	return query + body
+}
+
+func hash(s string) uint32 {
+	h := fnv.New32a()
+	h.Write([]byte(s))
+	return h.Sum32()
 }
 
 func getQuerySnippetFromBody(req *http.Request) string {

--- a/utils.go
+++ b/utils.go
@@ -47,7 +47,9 @@ func getAuth(req *http.Request) (string, string) {
 // getSessionId retrieves session id
 func getSessionId(req *http.Request) string {
 	params := req.URL.Query()
-	return params.Get("session_id")
+	sessionId := params.Get("session_id")
+	req.Header.Set("X-ClickHouse-Session-ID", sessionId)
+	return sessionId
 }
 
 // getQuerySnippet returns query snippet.

--- a/utils.go
+++ b/utils.go
@@ -48,7 +48,6 @@ func getAuth(req *http.Request) (string, string) {
 func getSessionId(req *http.Request) string {
 	params := req.URL.Query()
 	sessionId := params.Get("session_id")
-	req.Header.Set("X-ClickHouse-Session-ID", sessionId)
 	return sessionId
 }
 


### PR DESCRIPTION
A proposed naive approach to be able to stick to user session across multiple queries:

**Use Case the PR Should be solved :** 
Query #1: 
```CREATE TEMPORARY TABLE if not exists analyse AS SELECT * from system.numbers limit 100```
Query #2: 
```SELECT count(*) as total from analyse```

For each query same session-id should be passed. 

Please review