### PR TITLE
Change Dockerfile to run Chproxy under non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,20 @@
-FROM debian:12
+FROM debian:12-slim
 
-RUN apt update && apt install -y ca-certificates curl
+ARG USER=chproxy
+ARG UID=1000
+ARG GID=$UID
+
+RUN groupadd -g $GID $USER && \
+    useradd -u $UID -g $GID -m $USER && \
+    apt update && \
+    apt install -y ca-certificates curl
 
 COPY chproxy /
 
 EXPOSE 9090
 
+USER $USER
+
 ENTRYPOINT ["/chproxy"]
-CMD [ "--help" ]
+
+CMD ["--help"]


### PR DESCRIPTION
## Description

Changes:
1. Security improvement: the application now runs as a non-root user inside the container, following best practices for containerized environments. This helps reduce the potential impact of security vulnerabilities.
2. Image size optimization: switched the base image to `debian:12-slim`, reducing the overall image size from 291MB to 219MB.

For more information, refer to the following resources:
* [Sysdig's Dockerfile Best Practices](https://sysdig.com/learn-cloud-native/dockerfile-best-practices/#1-1-rootless-containers)
* [Kubernetes Security Checklist](https://kubernetes.io/docs/concepts/security/security-checklist/#images)

Fixes https://github.com/ContentSquare/chproxy/issues/515

## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


### Checklist

- [x] Linter passes correctly
- [ ] Add tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
