### PR TITLE
feat: cache: redis: tls: allow enabling without client certs

### DIFF
--- a/clients/redis.go
+++ b/clients/redis.go
@@ -22,7 +22,8 @@ func NewRedisClient(cfg config.RedisCacheConfig) (redis.UniversalClient, error) 
 		options.DB = cfg.DBIndex
 	}
 
-	if len(cfg.CertFile) != 0 || len(cfg.KeyFile) != 0 {
+	// maintain backwards compatibility in case of non-presence of enable_tls
+	if len(cfg.CertFile) != 0 || len(cfg.KeyFile) != 0 || cfg.EnableTLS {
 		tlsConfig, err := cfg.TLS.BuildTLSConfig(nil)
 		if err != nil {
 			return nil, err

--- a/config/config.go
+++ b/config/config.go
@@ -367,12 +367,10 @@ func (c *TLS) BuildTLSConfig(acm *autocert.Manager) (*tls.Config, error) {
 				c.CertFile, c.KeyFile, err)
 		}
 		tlsCfg.Certificates = []tls.Certificate{cert}
-	} else {
-		if acm == nil {
-			return nil, fmt.Errorf("autocert manager is not configured")
-		}
+	} else if acm != nil {
 		tlsCfg.GetCertificate = acm.GetCertificate
 	}
+
 	return &tlsCfg, nil
 }
 
@@ -965,7 +963,8 @@ type FileSystemCacheConfig struct {
 }
 
 type RedisCacheConfig struct {
-	TLS `yaml:",inline"`
+	TLS       `yaml:",inline"`
+	EnableTLS bool `yaml:"enable_tls,omitempty"`
 
 	Username  string                 `yaml:"username,omitempty"`
 	Password  string                 `yaml:"password,omitempty"`

--- a/docs/src/content/docs/configuration/default.md
+++ b/docs/src/content/docs/configuration/default.md
@@ -67,18 +67,22 @@ caches:
     # Applicable for cache mode: redis
     # You should use multiple addresses only if they all belong to the same redis cluster.
     redis:
-      # Paths to TLS cert and key files for the redis server.
-      # If you change the cert & key files while chproxy is running, you have to restart chproxy so that it loads them.
-      # Triggering a SIGHUP signal won't work as for the rest of the configuration.
-      cert_file: "redis tls cert file path"
-      key_file: "redis tls key file apth"
-      # Allow to skip the verification of the redis server certificate.
-      insecure_skip_verify: true
-
       addresses:
         - "localhost:16379"
       username: "user"
       password: "pass"
+      
+      # TLS: For backwards compatibility, having a non-empty cert_file and key_file also enables TLS configuration.
+      enable_tls: false
+
+      # TLS: Switch to true to disable server certificate validation ( e.g. when using self-signed certificates )
+      insecure_skip_verify: false
+      
+      # TLS: Paths to cert and key file for client-side X.509/mTLS authentication.
+      # Reload is NOT automatic : SIGHUP insufficient, chproxy must be restarted.
+      cert_file: "path to of tls client certificate to present to redis conn"
+      key_file: "path to of tls client cert key to present to redis conn"
+
     expire: 10s
 
 # Optional network lists, might be used as values for `allowed_networks`.


### PR DESCRIPTION
## Description

Allow enabling TLS on the connection to redis cache without specifying a client-side certificate & key pair.
This should fix #550 , but requires specifying `enable_tls: true` in the configuration.

## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


### Checklist

- [x] Linter passes correctly
- [x] Add tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
