### PR TITLE
Add ExecReload directive to chproxy service

### DIFF
--- a/docs/src/content/docs/install.md
+++ b/docs/src/content/docs/install.md
@@ -84,6 +84,7 @@ Type=notify
 User=chproxy
 Group=chproxy
 ExecStart=/usr/bin/chproxy -config /etc/chproxy/chproxy.yml
+ExecReload=kill -HUP $MAINPID
 TimeoutSec=30
 Restart=on-failure
 


### PR DESCRIPTION
so that systemd service can reloaded to fetch new changes from config file

## Description
This will be helpful in reloading chproxy systemd service on the fly to reload changes from config file. Previously, it wasn't there and `systemd relaod chproxy` would say something like "you can not run 'reload' operation on this service".

## Pull request type
Changes in documentation.

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe):


### Checklist

- [ ] Linter passes correctly
- [ ] Add tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary

## Does this introduce a breaking change?

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Further comments

nah, its just a simple change in documentation
