### PR TITLE
[BUG] Set Host header to match target host in proxied requests

### DIFF
--- a/scope.go
+++ b/scope.go
@@ -396,6 +396,8 @@ func (s *scope) decorateRequest(req *http.Request) (*http.Request, url.Values) {
 	if req.RequestURI == pingEndpoint {
 		req.URL.Scheme = s.host.Scheme()
 		req.URL.Host = s.host.Host()
+		// Set the Host header to match the target URL host
+		req.Host = req.URL.Host
 		return req, req.URL.Query()
 	}
 
@@ -445,6 +447,9 @@ func (s *scope) decorateRequest(req *http.Request) (*http.Request, url.Values) {
 	// Send request to the chosen host from cluster.
 	req.URL.Scheme = s.host.Scheme()
 	req.URL.Host = s.host.Host()
+
+	// Set the Host header to match the target URL host
+	req.Host = req.URL.Host
 
 	// Extend ua with additional info, so it may be queried
 	// via system.query_log.http_user_agent.

--- a/scope_test.go
+++ b/scope_test.go
@@ -523,3 +523,46 @@ func testGetScope(c *cluster, u *user, cu *clusterUser, sessionId string) *scope
 	}
 	return s
 }
+
+func TestDecorateRequestHostHeader(t *testing.T) {
+	testCases := []struct {
+		name       string
+		requestURI string
+		targetHost string
+	}{
+		{
+			name:       "ping endpoint",
+			requestURI: "/ping",
+			targetHost: "127.0.0.2:8123",
+		},
+		{
+			name:       "regular query",
+			requestURI: "/?query=SELECT%201",
+			targetHost: "127.0.0.3:9000",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			req, err := http.NewRequest("GET", "http://127.0.0.1"+tc.requestURI, nil)
+			if err != nil {
+				t.Fatalf("unexpected error while creating request: %s", err)
+			}
+			s := &scope{
+				id:          newScopeID(),
+				clusterUser: &clusterUser{name: "default"},
+				user:        &user{},
+				host:        topology.NewNode(&url.URL{Host: tc.targetHost}, nil, "", ""),
+			}
+
+			req, _ = s.decorateRequest(req)
+
+			if req.Host != tc.targetHost {
+				t.Fatalf("expected Host header %q; got %q", tc.targetHost, req.Host)
+			}
+			if req.URL.Host != tc.targetHost {
+				t.Fatalf("expected URL.Host %q; got %q", tc.targetHost, req.URL.Host)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

This PR ensures that the HTTP `Host` header is correctly set to match the target ClickHouse server's host when proxying requests. Previously, the `Host` header could retain the original proxy address, which could cause issues with host routing or server-side host validation.

According to the HTTP specification:

**[MDN - Host Header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Host)**
> The HTTP Host request header specifies **the host and port number of the server to which the request is being sent**. A Host header field **must be sent** in all HTTP/1.1 request messages.

**[RFC 9110 Section 7.2](https://datatracker.ietf.org/doc/html/rfc9110#section-7.2)**
> The "Host" header field in a request provides the **host and port information from the target URI**, enabling the origin server to distinguish among resources while servicing requests for multiple host names.
>
> The target URI's authority information is critical for handling a request. A user agent MUST generate a Host header field in a request unless it sends that information as an ":authority" pseudo-header field.

**Real-world impact:**

The incorrect `Host` header can cause issues in environments using host routing, such as AWS Application Load Balancers with [host-based routing rules](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/rule-condition-types.html#host-conditions), where requests are routed based on the `Host` header value.

**Example scenario from [issue #415](https://github.com/ContentSquare/chproxy/issues/415):**

### Before
```
Request to chproxy:
  Host: localhost:8124
  URL: http://localhost:8124/?query=SELECT 1

Proxied to ClickHouse:
  Host: localhost:8124  (incorrect - kept original)
  URL: https://backend.example.com:8123/?query=SELECT 1
```

### After
```
Request to chproxy:
  Host: localhost:8124
  URL: http://localhost:8124/?query=SELECT 1

Proxied to ClickHouse:
  Host: backend.example.com:8123 (correct - matches backend)
  URL: https://backend.example.com:8123/?query=SELECT 1
```

## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Checklist

- [x] Linter passes correctly
- [x] Add tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Further comments

**Fixes:** https://github.com/ContentSquare/chproxy/issues/415
