### PR TITLE
fix: improve node selection in sticky session

### DIFF
--- a/scope.go
+++ b/scope.go
@@ -58,9 +58,11 @@ type scope struct {
 }
 
 func newScope(req *http.Request, u *user, c *cluster, cu *clusterUser, sessionId string, sessionTimeout int) *scope {
-	h := c.getHost()
+	var h *topology.Node
 	if sessionId != "" {
 		h = c.getHostSticky(sessionId)
+	} else {
+		h = c.getHost()
 	}
 	var localAddr string
 	if addr, ok := req.Context().Value(http.LocalAddrContextKey).(net.Addr); ok {
@@ -874,27 +876,29 @@ func (c *cluster) getReplica() *replica {
 	return r
 }
 
+// getReplicaSticky returns replica by stickiness from the cluster.
+//
+// Always returns non-nil.
 func (c *cluster) getReplicaSticky(sessionId string) *replica {
-	idx := atomic.AddUint32(&c.nextReplicaIdx, 1)
 	n := uint32(len(c.replicas))
 	if n == 1 {
 		return c.replicas[0]
 	}
 
-	idx %= n
+	// handling sticky session
+	idx := hash(sessionId) % n
 	r := c.replicas[idx]
 
-	for i := uint32(1); i < n; i++ {
-		// handling sticky session
-		sessionId := hash(sessionId)
-		tmpIdx := (sessionId) % n
+	// TODO: In principle, sticky session must always proxy to the fixed replica continuously,
+	// no matter whether the replica is active or not.
+	for i := range n {
+		tmpIdx := (idx + i) % n
 		tmpRSticky := c.replicas[tmpIdx]
-		log.Debugf("Sticky replica candidate is: %s", tmpRSticky.name)
 		if !tmpRSticky.isActive() {
-			log.Debugf("Sticky session replica has been picked up, but it is not available")
+			log.Errorf("Sticky replica candidate %q for session_id %q is inactive", tmpRSticky.name, sessionId)
 			continue
 		}
-		log.Debugf("Sticky session replica is: %s, session_id: %d, replica_idx: %d, max replicas in pool: %d", tmpRSticky.name, sessionId, tmpIdx, n)
+		log.Debugf("Sticky replica for session_id %q: %q", sessionId, tmpRSticky.name)
 		return tmpRSticky
 	}
 	// The returned replica may be inactive. This is OK,
@@ -907,27 +911,25 @@ func (c *cluster) getReplicaSticky(sessionId string) *replica {
 //
 // Always returns non-nil.
 func (r *replica) getHostSticky(sessionId string) *topology.Node {
-	idx := atomic.AddUint32(&r.nextHostIdx, 1)
 	n := uint32(len(r.hosts))
 	if n == 1 {
 		return r.hosts[0]
 	}
 
-	idx %= n
+	// handling sticky session
+	idx := hash(sessionId) % n
 	h := r.hosts[idx]
 
-	// Scan all the hosts for the least loaded host.
-	for i := uint32(1); i < n; i++ {
-		// handling sticky session
-		sessionId := hash(sessionId)
-		tmpIdx := (sessionId) % n
+	// TODO: In principle, sticky session must always proxy to the fixed host continuously,
+	// no matter whether the host is active or not.
+	for i := range n {
+		tmpIdx := (idx + i) % n
 		tmpHSticky := r.hosts[tmpIdx]
-		log.Debugf("Sticky server candidate is: %s", tmpHSticky)
 		if !tmpHSticky.IsActive() {
-			log.Debugf("Sticky session server has been picked up, but it is not available")
+			log.Errorf("Sticky host candidate %q for session_id %q is inactive", tmpHSticky, sessionId)
 			continue
 		}
-		log.Debugf("Sticky session server is: %s, session_id: %d, server_idx: %d, max nodes in pool: %d", tmpHSticky, sessionId, tmpIdx, n)
+		log.Debugf("Sticky host for session_id %q: %q", sessionId, tmpHSticky)
 		return tmpHSticky
 	}
 

--- a/scope.go
+++ b/scope.go
@@ -886,7 +886,7 @@ func (c *cluster) getReplicaSticky(sessionId string) *replica {
 	}
 
 	// handling sticky session
-	idx := hash(sessionId) % n
+	idx := (hash(sessionId) >> 16) % n
 	r := c.replicas[idx]
 
 	// TODO: In principle, sticky session must always proxy to the fixed replica continuously,
@@ -917,7 +917,7 @@ func (r *replica) getHostSticky(sessionId string) *topology.Node {
 	}
 
 	// handling sticky session
-	idx := hash(sessionId) % n
+	idx := (hash(sessionId) & 0xFFFF) % n
 	h := r.hosts[idx]
 
 	// TODO: In principle, sticky session must always proxy to the fixed host continuously,

--- a/scope_test.go
+++ b/scope_test.go
@@ -396,10 +396,10 @@ func TestDecorateRequest(t *testing.T) {
 
 func TestGetHostSticky(t *testing.T) {
 	exceptedSessionHostMap := map[string]string{
-		"0": "127.0.0.22",
+		"0": "127.0.0.66",
 		"1": "127.0.0.33",
 		"2": "127.0.0.44",
-		"3": "127.0.0.55",
+		"3": "127.0.0.11",
 	}
 	c := testGetCluster()
 	for i := 0; i < 10000; i++ {
@@ -415,10 +415,10 @@ func TestIncQueued(t *testing.T) {
 	cu := testGetClusterUser()
 	c := testGetCluster()
 	expectedSessionHostMap := map[string]string{
-		"0": "127.0.0.22",
+		"0": "127.0.0.66",
 		"1": "127.0.0.33",
 		"2": "127.0.0.44",
-		"3": "127.0.0.55",
+		"3": "127.0.0.11",
 	}
 	if err := testConcurrentQuery(c, u, cu, 10000, expectedSessionHostMap); err != nil {
 		t.Fatalf("incQueue test err: %s", err)


### PR DESCRIPTION
## Description

<!--  Please explain the object of this PR and the changes you made.
A reference to a github issue would be appreciated. --> 

Fixed the bug where chproxy always selects nodes only from a small subset of all nodes, for any random `session_id`.

Additionally, resolved performance bottlenecks caused by inefficient usage `hash(sessionId)` within loops.

Closes #574 

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


### Checklist

- [x] Linter passes correctly
- [ ] Add tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary

## Does this introduce a breaking change?

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

By design, sticky sessions should consistently route all requests with the same `session_id` to the exact same node, regardless of whether the node is active or not. However, the current implementation fails to maintain this consistency when the selected node's active status changes during this period. Resolving this issue presents challenges, especially in chproxy topologies with 2 or more replicas, which may require introducing distributed storage solutions like Redis. I have added `TODO` in the code and will open another issue about this.

- Example 1: A sticky session initially routes requests to node `127.0.1.1` based on its `session_id`. If `127.0.1.1` later becomes inactive, subsequent requests with the same `session_id` are incorrectly rerouted to another active node (e.g., `127.0.2.2`) instead of remaining directed to `127.0.1.1`.
- Example 2: A sticky session should route to node `127.0.1.1` but initially selects `127.0.2.2` because `127.0.1.1` is inactive. When `127.0.1.1` later becomes active, subsequent requests with the same `session_id` are incorrectly switched to `127.0.1.1`, breaking session stickiness.
