### PR TITLE
Idle Connection Timeout Configuration

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -40,6 +40,8 @@ max_error_reason_size: <byte_size>
 connection_pool:
   max_idle_conns: 100
   max_idle_conns_per_host: 2
+  # Connection idle timeout must be < Clickhouse `keep_alive_timeout`.
+  idle_conn_timeout: 9
 
 server:
   <server_config> [optional]

--- a/config/config.go
+++ b/config/config.go
@@ -42,6 +42,7 @@ var (
 	defaultConnectionPool = ConnectionPool{
 		MaxIdleConns:        100,
 		MaxIdleConnsPerHost: 2,
+		IdleConnTimeout:     Duration(9 * time.Second),
 	}
 
 	defaultExecutionTime = Duration(120 * time.Second)
@@ -1061,6 +1062,10 @@ type ConnectionPool struct {
 
 	// Maximum number of idle connections between chproxy and particuler ClickHouse instance
 	MaxIdleConnsPerHost int `yaml:"max_idle_conns_per_host,omitempty"`
+
+	// Time that an idle connection is kept in the pool before being discarded.
+	// Should be set below the ClickHouse server's keep_alive_timeout.
+	IdleConnTimeout Duration `yaml:"idle_conn_timeout,omitempty"`
 
 	// Catches all undefined fields
 	XXX map[string]interface{} `yaml:",inline"`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -219,6 +219,7 @@ var fullConfig = Config{
 	ConnectionPool: ConnectionPool{
 		MaxIdleConns:        100,
 		MaxIdleConnsPerHost: 2,
+		IdleConnTimeout:     Duration(9 * time.Second),
 	},
 
 	Users: []User{
@@ -946,6 +947,7 @@ param_groups:
 connection_pool:
   max_idle_conns: 100
   max_idle_conns_per_host: 2
+  idle_conn_timeout: 9s
 `, redisPort)
 	tested := fullConfig.String()
 	if tested != expected {

--- a/config/testdata/full.yml
+++ b/config/testdata/full.yml
@@ -111,6 +111,10 @@ connection_pool:
   # Number of connections per ClickHouse host to keep open
   # when they are not needed for clients.
   max_idle_conns_per_host: 2
+  # Idle Timeout For Connections To Clickhouse. This value must be < the Clickhouse
+  # `keep_alive_timeout` to prevent graceful disconnection race-conditions that can
+  # result in Bad Gateway (unable to reach host errors)
+  idle_conn_timeout: 9s
 
 # Settings for `chproxy` input interfaces.
 server:

--- a/proxy.go
+++ b/proxy.go
@@ -62,7 +62,7 @@ func newReverseProxy(cfgCp *config.ConnectionPool) *reverseProxy {
 		ForceAttemptHTTP2:     true,
 		MaxIdleConns:          cfgCp.MaxIdleConns,
 		MaxIdleConnsPerHost:   cfgCp.MaxIdleConnsPerHost,
-		IdleConnTimeout:       90 * time.Second,
+		IdleConnTimeout:       time.Duration(cfgCp.IdleConnTimeout),
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
 	}


### PR DESCRIPTION
## Description

Allows connections in the pool to have a configurable idle timeout. This is required to ensure the idleTimeout < the configured clickhouse keep-alive timeout, preventing race conditions that lead to timeout errors reporting "unable to reach server".

- Adds configuration for connection pool idle connetion timeouts
- Decreases the default idle connection timeout to be < the default Clickhouse keep-alive timeout (10s)

Fixes: #92


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


### Checklist

- [x] Linter passes correctly
- [ ] Add tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary

## Does this introduce a breaking change?

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
