### PR TITLE
fix: prevent service degradation on config reload failure

### DIFF
--- a/main.go
+++ b/main.go
@@ -299,12 +299,26 @@ func proxyConfigChanged(cfgCp *config.ConnectionPool, rp *reverseProxy) bool {
 }
 
 func applyConfig(cfg *config.Config) error {
-	if proxy == nil || proxyConfigChanged(&cfg.ConnectionPool, proxy) {
-		proxy = newReverseProxy(&cfg.ConnectionPool)
+	needNewProxy := proxy == nil || proxyConfigChanged(&cfg.ConnectionPool, proxy)
+
+	if needNewProxy {
+		newProxy := newReverseProxy(&cfg.ConnectionPool)
+		if err := newProxy.applyConfig(cfg); err != nil {
+			close(newProxy.reloadSignal)
+			newProxy.reloadWG.Wait()
+			return err
+		}
+		if proxy != nil {
+			close(proxy.reloadSignal)
+			proxy.reloadWG.Wait()
+		}
+		proxy = newProxy
+	} else {
+		if err := proxy.applyConfig(cfg); err != nil {
+			return err
+		}
 	}
-	if err := proxy.applyConfig(cfg); err != nil {
-		return err
-	}
+
 	allowedNetworksHTTP.Store(&cfg.Server.HTTP.AllowedNetworks)
 	allowedNetworksHTTPS.Store(&cfg.Server.HTTPS.AllowedNetworks)
 	allowedNetworksMetrics.Store(&cfg.Server.Metrics.AllowedNetworks)

--- a/proxy.go
+++ b/proxy.go
@@ -78,7 +78,7 @@ func newReverseProxy(cfgCp *config.ConnectionPool) *reverseProxy {
 		},
 		reloadSignal:        make(chan struct{}),
 		reloadWG:            sync.WaitGroup{},
-		maxIdleConns:        cfgCp.MaxIdleConnsPerHost,
+		maxIdleConns:        cfgCp.MaxIdleConns,
 		maxIdleConnsPerHost: cfgCp.MaxIdleConnsPerHost,
 	}
 }


### PR DESCRIPTION
## Summary

- **Atomic config reload**: When a new `ConnectionPool` config is detected, the new proxy is fully initialized and validated before replacing the old one, preventing partial/broken state exposure.
- **Graceful old proxy shutdown**: After the new proxy takes over, the old proxy's `reloadSignal` is closed and its goroutines are waited on via `reloadWG`, avoiding goroutine leaks.
- **Fix `maxIdleConns` field assignment**: In `newReverseProxy`, `maxIdleConns` was incorrectly set to `cfgCp.MaxIdleConnsPerHost`; corrected to `cfgCp.MaxIdleConns`.

## Test plan

- [x] Verify that a config reload with a changed `ConnectionPool` correctly creates and applies the new proxy before discarding the old one
- [x] Verify that a failed config reload does not leave the service in a degraded state (old proxy remains active)
- [x] Verify that the old proxy goroutines are properly cleaned up after reload
- [x] Verify that `maxIdleConns` is correctly set from `cfg.ConnectionPool.MaxIdleConns`

🤖 Generated with [Claude Code](https://claude.com/claude-code)