### PR TITLE
chore migrate gihub actions to Action Manager

### DIFF
--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -12,10 +12,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: ContentSquare/actions-checkout@approved-v4
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: ContentSquare/actions-setup-go@approved-v5
       with:
         go-version-file: go.mod
 
@@ -27,7 +27,7 @@ jobs:
 
     - name: Update coverage report
       if: github.ref == 'refs/heads/master'
-      uses: ncruces/go-coverage-report@21fa4b59396f242b81896a3cd212a463589b6742
+      uses: ContentSquare/ncruces-go-coverage-report@approved-21fa4b59396f242b81896a3cd212a463589b6742
       with:
         report: 'false'
         chart: 'true'

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -14,13 +14,13 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: ContentSquare/actions-checkout@approved-v4
 
-      - uses: actions/setup-go@v5
+      - uses: ContentSquare/actions-setup-go@approved-v5
         with:
           go-version-file: go.mod
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: contentsquare/golangci-golangci-lint-action@approved-v6
         with:
           version: v1.64.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,20 +14,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: ContentSquare/actions-checkout@approved-v4
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: ContentSquare/actions-setup-go@approved-v5
         with:
           go-version-file: go.mod
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: ContentSquare/docker-setup-buildx-action@approved-v3
 
       - name: Docker login
-        uses: docker/login-action@v3
+        uses: ContentSquare/docker-login-action@approved-v3
         with:
           username: ${{ secrets.docker_username }}
           password: ${{ secrets.docker_password }}


### PR DESCRIPTION
# Description

Migrate all GitHub Actions workflow files across ContentSquare repositories to use the Actions Manager Fork-and-Approved-Tag security model.

All direct upstream action references (e.g. `actions/checkout@v4`) have been replaced with their ContentSquare-managed fork equivalents (e.g. `ContentSquare/actions-checkout@approved-v4`) using `platform_github/allowed-actions.yaml` as the source of truth.

## Motivation and Context

The [Actions Manager](https://github.com/ContentSquare/platform_github?tab=readme-ov-file#actions-manager-recommended) implements a Fork-and-Approved-Tag security model to prevent supply chain attacks. Using direct upstream action references bypasses this model and will be blocked by security controls in the future.

This change ensures all workflows use only ContentSquare-controlled forks with security-reviewed approved tags, providing:
- **Supply chain protection**: only ContentSquare-controlled forks are used
- **Approved tags only**: no raw upstream tags
- **Audit trail**: complete approval and usage history

## Breaking Changes

No breaking changes. The ContentSquare fork actions are functionally identical to their upstream counterparts — only the reference syntax changes.

Actions not present in `allowed-actions.yaml` (no approved fork available yet) were left unchanged.

## How Has This Been Tested?

See the following CI runs in this PR